### PR TITLE
WorkAround - Avoid toggle on the stove power setting when calling a specific HVAC mode

### DIFF
--- a/custom_components/maestro_mcz/climate.py
+++ b/custom_components/maestro_mcz/climate.py
@@ -189,8 +189,9 @@ class MczClimateEntity(CoordinatorEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode):
         if(self._power_configuration is not None):
+            if(self.hvac_mode is not None and self.hvac_mode is not hvac_mode): #avoid sending the same hvac mode to the API because this will result in a toggle of the power setting of the stove
                 await self.coordinator._maestroapi.ActivateProgram(self._power_configuration.configuration.sensor_id, self._power_configuration.configuration_id, True)
-                await self.coordinator.async_request_refresh()
+            await self.coordinator.async_request_refresh()
 
     async def async_set_fan_mode(self, fan_mode):
         if(self._fan_configuration is not None):


### PR DESCRIPTION
When you want to call a specific HVAC mode like (e.g HVAC.HEAT or HVACMode.OFF)

Up till now, when the HVAC mode had already the value you wanted to set, this would had been resulted in a toggle of the stoves current power setting often resulting in the exact opposite of the intended action .

We provided this integration with a workaround by checking the HVAC mode before sending the call to the API.
This doesn't come without inconvenience unfortunately,  since this is a workaround for an API issue, this will only avoid the toggle of the power setting when at least one polling time (default 30secs) has passed since the last HVAC MODE SET action.