### PR TITLE
Add support for water temperature sensor

### DIFF
--- a/custom_components/maestro_mcz/button.py
+++ b/custom_components/maestro_mcz/button.py
@@ -1,6 +1,6 @@
 """Platform for Button integration."""
-from custom_components.maestro_mcz.maestro.responses.model import SensorConfiguration
-from custom_components.maestro_mcz.maestro.types.enums import TypeEnum
+from ..maestro_mcz.maestro.responses.model import SensorConfiguration
+from ..maestro_mcz.maestro.types.enums import TypeEnum
 from . import MczCoordinator, models
 
 from homeassistant.components.button import (

--- a/custom_components/maestro_mcz/climate.py
+++ b/custom_components/maestro_mcz/climate.py
@@ -1,8 +1,8 @@
 """Platform for Climate integration."""
 import logging
 
-from custom_components.maestro_mcz import models
-from custom_components.maestro_mcz.maestro.responses.model import Configuration, SensorConfiguration
+from ..maestro_mcz import models
+from ..maestro_mcz.maestro.responses.model import SensorConfiguration
 
 from . import MczCoordinator
 

--- a/custom_components/maestro_mcz/climate.py
+++ b/custom_components/maestro_mcz/climate.py
@@ -189,8 +189,9 @@ class MczClimateEntity(CoordinatorEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode):
         if(self._power_configuration is not None):
+            if(self.hvac_mode is not None and self.hvac_mode is not hvac_mode): #avoid sending the same hvac mode to the API because this will result in a toggle of the power setting of the stove
                 await self.coordinator._maestroapi.ActivateProgram(self._power_configuration.configuration.sensor_id, self._power_configuration.configuration_id, True)
-                await self.coordinator.async_request_refresh()
+            await self.coordinator.async_request_refresh()
 
     async def async_set_fan_mode(self, fan_mode):
         if(self._fan_configuration is not None):

--- a/custom_components/maestro_mcz/fan.py
+++ b/custom_components/maestro_mcz/fan.py
@@ -1,8 +1,8 @@
 """Platform for Fan integration."""
 import logging
 
-from custom_components.maestro_mcz.maestro.responses.model import SensorConfiguration
-from custom_components.maestro_mcz.maestro.types.enums import TypeEnum
+from ..maestro_mcz.maestro.responses.model import SensorConfiguration
+from ..maestro_mcz.maestro.types.enums import TypeEnum
 from . import MczCoordinator, models
 
 from homeassistant.components.fan import (

--- a/custom_components/maestro_mcz/models.py
+++ b/custom_components/maestro_mcz/models.py
@@ -224,7 +224,8 @@ supported_buttons = [
 
 supported_sensors = [
     SensorMczConfigItem("Current State","state","mdi:power", None, None, EntityCategory.DIAGNOSTIC, None, None, True),
-    SensorMczConfigItem("Temperature","temp_amb_install","mdi:thermometer", UnitOfTemperature.CELSIUS, None, None, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),
+    SensorMczConfigItem("Ambient Temperature","temp_amb_install","mdi:thermometer", UnitOfTemperature.CELSIUS, None, None, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),
+    SensorMczConfigItem("Water Temperature","temp_caldaia","mdi:water-thermometer", UnitOfTemperature.CELSIUS, None, None, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),
     SensorMczConfigItem("Current Mode","mode","mdi:calendar-multiselect", None, None, EntityCategory.DIAGNOSTIC, None, None, True),
     SensorMczConfigItem("Exhaust Temperature","temp_fumi","mdi:thermometer", UnitOfTemperature.CELSIUS, None, EntityCategory.DIAGNOSTIC, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),
     SensorMczConfigItem("Board Temperature","temp_scheda","mdi:thermometer", UnitOfTemperature.CELSIUS, None, EntityCategory.DIAGNOSTIC, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),

--- a/custom_components/maestro_mcz/number.py
+++ b/custom_components/maestro_mcz/number.py
@@ -1,6 +1,6 @@
 """Platform for Number integration."""
-from custom_components.maestro_mcz.maestro.responses.model import SensorConfiguration
-from custom_components.maestro_mcz.maestro.types.enums import TypeEnum
+from ..maestro_mcz.maestro.responses.model import SensorConfiguration
+from ..maestro_mcz.maestro.types.enums import TypeEnum
 from . import MczCoordinator, models
 
 from homeassistant.components.number import (

--- a/custom_components/maestro_mcz/select.py
+++ b/custom_components/maestro_mcz/select.py
@@ -1,6 +1,6 @@
 """Platform for Select integration."""
-from custom_components.maestro_mcz.maestro.responses.model import SensorConfiguration
-from custom_components.maestro_mcz.maestro.types.enums import TypeEnum
+from ..maestro_mcz.maestro.responses.model import SensorConfiguration
+from ..maestro_mcz.maestro.types.enums import TypeEnum
 from . import MczCoordinator, models
 
 from homeassistant.components.select import (

--- a/custom_components/maestro_mcz/sensor.py
+++ b/custom_components/maestro_mcz/sensor.py
@@ -16,7 +16,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     entities = []
     for stove in stoveList:
         stove:MczCoordinator = stove
-        supported_sensors = filter(lambda supported_sensor:(any(supported_sensor.sensor_get_name == sensor_name_state for sensor_name_state in dir(stove.maestroapi.State)) or any(supported_sensor.sensor_get_name == sensor_name_status for sensor_name_status in dir(stove.maestroapi.Status))),iter(models.supported_sensors))
+        supported_sensors = filter(lambda supported_sensor:(any((supported_sensor.sensor_get_name == sensor_name_state and getattr(stove.maestroapi.State, sensor_name_state) is not None) for sensor_name_state in dir(stove.maestroapi.State)) or any((supported_sensor.sensor_get_name == sensor_name_status and getattr(stove.maestroapi.Status, sensor_name_status) is not None) for sensor_name_status in dir(stove.maestroapi.Status))),iter(models.supported_sensors))
         if(supported_sensors is not None):
             for supported_sensor in supported_sensors:
                 if(supported_sensor is not None):

--- a/custom_components/maestro_mcz/switch.py
+++ b/custom_components/maestro_mcz/switch.py
@@ -1,6 +1,6 @@
 """Platform for Switch integration."""
-from custom_components.maestro_mcz.maestro.responses.model import SensorConfiguration
-from custom_components.maestro_mcz.maestro.types.enums import TypeEnum
+from ..maestro_mcz.maestro.responses.model import SensorConfiguration
+from ..maestro_mcz.maestro.types.enums import TypeEnum
 from . import MczCoordinator, models
 
 from homeassistant.components.switch import (


### PR DESCRIPTION
Add support for the water temperature shown by Hydro stove models.
=> renaming existing 'Temperature' sensor to 'Ambient Temperature' to make the difference more clear.
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/db8a1ba5-5a89-48a2-ab78-d35287ac3fd7)

We now also avoid showing sensors where the value is NULL (meaning this model doesn't have this sensor)
