### PR TITLE
Add basic support for M1+ Models

### DIFF
--- a/custom_components/maestro_mcz/models.py
+++ b/custom_components/maestro_mcz/models.py
@@ -157,8 +157,10 @@ class SensorMczConfigItem(MczConfigItem):
     display_precision: int | None = None
     device_class: SensorDeviceClass | None = None
     state_class: SensorStateClass | None = None
+    api_value_renames: dict[str,str] | None = None
 
-    def __init__(self, user_friendly_name:str, sensor_get_name:str, icon:str, unit:str|None, display_precision:int|None ,category: EntityCategory | None, device_class: SensorDeviceClass | None, state_class: SensorStateClass | None, enabled_by_default: bool):
+
+    def __init__(self, user_friendly_name:str, sensor_get_name:str, icon:str, unit:str|None, display_precision:int|None ,category: EntityCategory | None, device_class: SensorDeviceClass | None, state_class: SensorStateClass | None, enabled_by_default: bool, api_value_renames: dict[str,str] | None = None):
         super().__init__(user_friendly_name)
         self.sensor_get_name = sensor_get_name
         self.icon = icon
@@ -168,67 +170,82 @@ class SensorMczConfigItem(MczConfigItem):
         self.device_class = device_class
         self.state_class = state_class
         self.enabled_by_default = enabled_by_default
+        self.api_value_renames = api_value_renames
 
 supported_power_settings = [
     PowerSettingMczConfigItem("Power", "fase_op", "com_on_off", "Spegnimento", True),
-    PowerSettingMczConfigItem("Power", "fase_op", "m1_stato_stufa", "Spegnimento", True),
+    PowerSettingMczConfigItem("Power", "fase_op", "m1_stato_stufa", "Spegnimento", True), #for first generation M1+
 ]
 
 supported_climate_function_modes = [
     ClimateFunctionModeMczConfigItem("Mode", "mode", "mod_funz", "set_mod", True, {"dynamic":"auto"}),
+    ClimateFunctionModeMczConfigItem("Mode", "mode", "m1_mod_lav_att", "set_mod", True, {"dynamic":"auto", "power":"turbo"}), #for first generation M1+
 ]
 
 supported_thermostats = [
     ThermostatMczConfigItem("Ambient Temperature", "set_amb1", "set_amb1", "Set_amb_temp", True),
+     ThermostatMczConfigItem("Ambient Temperature", "set_amb1", "m1_set_amb1", "Set_amb_temp", True), #for first generation M1+
     ThermostatMczConfigItem("Ambient Temperature 2", "set_amb2", "set_amb2", "Set_amb_temp", True),
+    ThermostatMczConfigItem("Ambient Temperature 2", "set_amb2", "m1_set_amb2", "Set_amb_temp", True), #for first generation M1+
     ThermostatMczConfigItem("Ambient Temperature 3", "set_amb3", "set_amb3", "Set_amb_temp", True),
+    ThermostatMczConfigItem("Ambient Temperature 3", "set_amb3", "m1_set_amb3", "Set_amb_temp", True), #for first generation M1+
 ]
 
 supported_pots = [
-    PotMczConfigItem("Manual Power", "set_pot_man", "set_pot_man", "Set_pot", True)
+    PotMczConfigItem("Manual Power", "set_pot_man", "set_pot_man", "Set_pot", True),
+    PotMczConfigItem("Manual Power", "set_pot_man", "m1_potenza_att", "Set_pot", True), #for first generation M1+
 ]
 
 supported_fans = [
     FanMczConfigItem("Fan 1", "set_vent_v1", "set_vent_v1", "set_v1", True),
+    FanMczConfigItem("Fan 1", "set_vent_v1", "m1_set_vent_v1", "set_v1", True),  #for first generation M1+
     FanMczConfigItem("Fan 2", "set_vent_v2", "set_vent_v2", "set_v2", True),
+    FanMczConfigItem("Fan 2", "set_vent_v2", "m1_set_vent_v2", "set_v2", True),  #for first generation M1+
     FanMczConfigItem("Fan 3", "set_vent_v3", "set_vent_v3", "set_v3", True),
+    FanMczConfigItem("Fan 3", "set_vent_v3", "m1_set_vent_v3", "set_v3", True),  #for first generation M1+
 ]
 
 supported_switches = [
     SwitchMczConfigItem("Start / Stop", "att_eco", "att_eco", "Start&Stop", "mdi:leaf", None, True),
-    SwitchMczConfigItem("Timer", "crono_enabled", "att", "Crono", "mdi:timer", None, True),
+    SwitchMczConfigItem("Start / Stop", "att_eco", "m1_att_eco", "Start&Stop", "mdi:leaf", None, True), #for first generation M1+
+    SwitchMczConfigItem("Timer", "crono_enabled", "att", "Crono", "mdi:timer", None, True),   
+    SwitchMczConfigItem("Timer", "crono_enabled", "m1_crono_enabled", "Crono", "mdi:timer", None, True),  #for first generation M1+  
+    #SwitchMczConfigItem("Silent Mode", "silent_enabled", "m1_silent_enabled", "set_v1", "mdi:fan-off", None, True),  #for first generation M1+
 ]
 
 supported_numbers = [
     #start/stop
-    NumberMczConfigItem("Start / Stop - Delay in Ignition", "rit_usc_standby", "rit_usc_standby", "Start&Stop", "auto", "mdi:fire", UnitOfTime.SECONDS ,EntityCategory.CONFIG, None, True),
-    NumberMczConfigItem("Start / Stop - Delay in Shutdown", "rit_ing_standby", "rit_ing_standby", "Start&Stop", "auto", "mdi:fire-off", UnitOfTime.SECONDS ,EntityCategory.CONFIG, None, True),
+    NumberMczConfigItem("Start / Stop - Delay in Ignition", "rit_usc_standby", "rit_usc_standby", "Start&Stop", "auto", "mdi:fire", UnitOfTime.SECONDS ,EntityCategory.CONFIG, None, True),    
+    NumberMczConfigItem("Start / Stop - Delay in Shutdown", "rit_ing_standby", "rit_ing_standby", "Start&Stop", "auto", "mdi:fire-off", UnitOfTime.SECONDS ,EntityCategory.CONFIG, None, True), 
+    NumberMczConfigItem("Start / Stop - Delay in Shutdown", "rit_ing_standby", "m1_rit_ing_standby", "Start&Stop", "auto", "mdi:fire-off", UnitOfTime.SECONDS ,EntityCategory.CONFIG, None, True), #for first generation M1+ 
     NumberMczConfigItem("Start / Stop - Negative Hysteresis", "ist_eco_neg_amb", "ist_eco_neg_amb", "Start&Stop", "auto", "mdi:thermometer-minus", UnitOfTemperature.CELSIUS ,EntityCategory.CONFIG, NumberDeviceClass.TEMPERATURE, True),
-    NumberMczConfigItem("Start / Stop - Positive Hysteresis", "ist_eco_pos_amb", "ist_eco_pos_amb", "Start&Stop", "auto", "mdi:thermometer-plus", UnitOfTemperature.CELSIUS ,EntityCategory.CONFIG, NumberDeviceClass.TEMPERATURE, True),
+    NumberMczConfigItem("Start / Stop - Negative Hysteresis", "ist_eco_neg_amb", "m1_ist_eco_neg_amb", "Start&Stop", "auto", "mdi:thermometer-minus", UnitOfTemperature.CELSIUS ,EntityCategory.CONFIG, NumberDeviceClass.TEMPERATURE, True),  #for first generation M1+
+    NumberMczConfigItem("Start / Stop - Positive Hysteresis", "ist_eco_pos_amb", "ist_eco_pos_amb", "Start&Stop", "auto", "mdi:thermometer-plus", UnitOfTemperature.CELSIUS ,EntityCategory.CONFIG, NumberDeviceClass.TEMPERATURE, True),  
     #ambient
     NumberMczConfigItem("Ambient - Negative Hysteresis", "ist_neg_amb", "ist_neg_amb", "Ambiente", "auto", "mdi:thermometer-minus", UnitOfTemperature.CELSIUS ,EntityCategory.CONFIG, NumberDeviceClass.TEMPERATURE, True),
     NumberMczConfigItem("Ambient - Positive Hysteresis", "ist_pos_amb", "ist_pos_amb", "Ambiente", "auto", "mdi:thermometer-plus", UnitOfTemperature.CELSIUS ,EntityCategory.CONFIG, NumberDeviceClass.TEMPERATURE, True),
 ]
 
 supported_selectors = [
-    SelectMczConfigItem("Tones", "toni_buzz", "toni_buzz", "Toni", "mdi:volume-high", EntityCategory.CONFIG, True, {"0":"Silent", "1":"Normal", "2":"High"})
+    SelectMczConfigItem("Tones", "toni_buzz", "toni_buzz", "Toni", "mdi:volume-high", EntityCategory.CONFIG, True, {"0":"Silent", "1":"Normal", "2":"High"}),
+    SelectMczConfigItem("Tones", "toni_buzz", "m1_toni_buzz", "Toni", "mdi:volume-high", EntityCategory.CONFIG, True, {"0":"Silent", "1":"Normal", "2":"High"}), #for first generation M1+
+]
+
+supported_buttons = [
+    ButtonMczConfigItem("Alarm Reset","com_reset_allarm","Reset Allarme","mdi:auto-fix", EntityCategory.DIAGNOSTIC, True),
+    ButtonMczConfigItem("Alarm Reset","m1_com_reset_allarm","Reset Allarme","mdi:auto-fix", EntityCategory.DIAGNOSTIC, True), #for first generation M1+
 ]
 
 supported_binary_sensors = [
     BinarySensorMczConfigItem("Alarm","is_in_error","mdi:alert", EntityCategory.DIAGNOSTIC, BinarySensorDeviceClass.PROBLEM, True),
 ]
 
-supported_buttons = [
-    ButtonMczConfigItem("Alarm Reset","com_reset_allarm","Reset Allarme","mdi:auto-fix", EntityCategory.DIAGNOSTIC, True),
-]
-
-
 supported_sensors = [
     SensorMczConfigItem("Current State","state","mdi:power", None, None, EntityCategory.DIAGNOSTIC, None, None, True),
     SensorMczConfigItem("Ambient Temperature","temp_amb_install","mdi:thermometer", UnitOfTemperature.CELSIUS, None, None, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),
     SensorMczConfigItem("Water Temperature","temp_caldaia","mdi:water-thermometer", UnitOfTemperature.CELSIUS, None, None, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),
     SensorMczConfigItem("Puffer Temperature","temp_puffer","mdi:water-thermometer", UnitOfTemperature.CELSIUS, None, None, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),
-    SensorMczConfigItem("Current Mode","mode","mdi:calendar-multiselect", None, None, EntityCategory.DIAGNOSTIC, None, None, True),
+    SensorMczConfigItem("Current Mode","mode","mdi:calendar-multiselect", None, None, EntityCategory.DIAGNOSTIC, None, None, True, {"dynamic":"auto", "power":"turbo"}), #renames are needed for first generation M1+ (for consistency in the different modes compaired to other models)
     SensorMczConfigItem("Exhaust Temperature","temp_fumi","mdi:thermometer", UnitOfTemperature.CELSIUS, None, EntityCategory.DIAGNOSTIC, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),
     SensorMczConfigItem("Board Temperature","temp_scheda","mdi:thermometer", UnitOfTemperature.CELSIUS, None, EntityCategory.DIAGNOSTIC, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),
     SensorMczConfigItem("Exhaust Fan Speed","vel_real_ventola_fumi","mdi:fan-chevron-up", REVOLUTIONS_PER_MINUTE, None, EntityCategory.DIAGNOSTIC, None, SensorStateClass.MEASUREMENT, True),

--- a/custom_components/maestro_mcz/sensor.py
+++ b/custom_components/maestro_mcz/sensor.py
@@ -42,6 +42,7 @@ class MczSensorEntity(CoordinatorEntity, SensorEntity):
         self._prop = supported_sensor.sensor_get_name
         self._enabled_default = supported_sensor.enabled_by_default
         self._category = supported_sensor.category
+        self._api_value_renames = supported_sensor.api_value_renames
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -57,12 +58,17 @@ class MczSensorEntity(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self):
+        value = None
+        
         if(hasattr(self.coordinator._maestroapi.State, self._prop)):
-            return getattr(self.coordinator._maestroapi.State, self._prop)
+            value = getattr(self.coordinator._maestroapi.State, self._prop)
         elif(hasattr(self.coordinator._maestroapi.Status, self._prop)):
-            return getattr(self.coordinator._maestroapi.Status, self._prop)
+            value = getattr(self.coordinator._maestroapi.Status, self._prop)
+
+        if(self._api_value_renames is not None and value in self._api_value_renames.keys()):
+            return self._api_value_renames[value]
         else:
-            return None
+            return value
 
     @property
     def entity_registry_enabled_default(self) -> bool:


### PR DESCRIPTION
Add basic support for M1+ Models.
Example of an M1+ diagnostics file:
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/1210d79b-a12e-41a1-9aba-b5d788d207aa)
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/f67bd0e8-8aa6-4438-a4bf-773300ed5530)
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/c1995880-d493-47ef-a1cd-8341bac2dc07)
