### PR TITLE
Avoid adding a stove without a valid serial number

### DIFF
--- a/custom_components/maestro_mcz/__init__.py
+++ b/custom_components/maestro_mcz/__init__.py
@@ -54,7 +54,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         stove:MaestroStove = stove
         coordinator = MczCoordinator(hass, stove, pollling_interval)
         await coordinator.async_config_entry_first_refresh()
-        stoveList.append(coordinator)
+        if(coordinator.maestroapi.Status.sm_sn): #avoid adding a disconnected stove without serial number
+            stoveList.append(coordinator)
 
     hass.data[DOMAIN][entry.entry_id] = stoveList
 


### PR DESCRIPTION
Avoid adding a stove without a valid serial number.
This could happen when your stove is disconnected from the cloud.
The integration would try to add a second stove with an empty serial number.
This has been fixed now