### PR TITLE
Fix disconnected stoves, due to empty serial number

### DIFF
--- a/custom_components/maestro_mcz/__init__.py
+++ b/custom_components/maestro_mcz/__init__.py
@@ -54,7 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         stove:MaestroStove = stove
         coordinator = MczCoordinator(hass, stove, pollling_interval)
         await coordinator.async_config_entry_first_refresh()
-        if(coordinator.maestroapi.Status.sm_sn): #avoid adding a disconnected stove without serial number
+        if(coordinator.maestroapi.UniqueCode): #avoid adding a disconnected stove without serial number
             stoveList.append(coordinator)
 
     hass.data[DOMAIN][entry.entry_id] = stoveList
@@ -113,7 +113,7 @@ class MczCoordinator(DataUpdateCoordinator):
      
     def get_device_info(self) -> DeviceInfo:
         return DeviceInfo(
-            identifiers={(DOMAIN, self._maestroapi.Status.sm_sn)},
+            identifiers={(DOMAIN, self._maestroapi.UniqueCode)},
             name=self._maestroapi.Name,
             manufacturer=MANUFACTURER,
             model=self._maestroapi.Model.model_name,


### PR DESCRIPTION
As described in #75 for older models an empty serial number is received from the cloud.
This would result in the stove not showing up anymore since  V0.4.2.

This has now been addressed.

NOTE: For some stove models this might create a duplicate stove device entity inside the integration after upgrading to this version. 
In that case just re-adding the integration from scratch should solve your problem.