### PR TITLE
Add proper fan speed and preset support.

### DIFF
--- a/custom_components/maestro_mcz/fan.py
+++ b/custom_components/maestro_mcz/fan.py
@@ -1,5 +1,6 @@
 """Platform for Fan integration."""
 import logging
+import math
 
 from typing import Any
 from ..maestro_mcz.maestro.responses.model import SensorConfiguration, SensorConfigurationMultipleModes
@@ -13,6 +14,7 @@ from homeassistant.components.fan import (
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util.percentage import ranged_value_to_percentage, percentage_to_ranged_value
 
 
 from .const import DOMAIN
@@ -37,12 +39,17 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
 class MczFanEntity(CoordinatorEntity, FanEntity):
     _attr_has_entity_name = True
-    _attr_preset_mode = None
-    _attr_is_on = None
+    _attr_available: bool = True
     #
+    _attr_is_on: bool | None = None
+    _attr_percentage: int | None = None
+    _attr_preset_mode: str | None = None
+    _attr_preset_modes: list[str] | None = None
+    _attr_speed_count: int = 0
+    #
+    _supported_fan: models.FanMczConfigItem | None = None
     _fan_configuration: SensorConfigurationMultipleModes | None = None
     _current_fan_configuration: SensorConfiguration | None = None
-    _presets: list | None = None
 
     def __init__(self, coordinator, supported_fan: models.FanMczConfigItem, matching_fan_configuration: SensorConfigurationMultipleModes):
         super().__init__(coordinator)
@@ -53,24 +60,17 @@ class MczFanEntity(CoordinatorEntity, FanEntity):
         self._prop = supported_fan.sensor_get_name
         self._enabled_default = supported_fan.enabled_by_default
         self._category = supported_fan.category
+        self._supported_fan = supported_fan
         self._fan_configuration = matching_fan_configuration
         
-        self.update_features_based_on_current_stove_state()
+        self.update_features_based_on_current_stove_mode() #each mode of the stove has other fan settings, so we need to update this accordingly
 
         self.handle_coordinator_update_internal() #getting the initial update directly without delay
 
     @property
     def device_info(self) -> DeviceInfo:
         return self.coordinator.get_device_info()
-
-    @property
-    def is_on(self) -> bool:
-        return self._attr_is_on
-
-    @property
-    def preset_mode(self) -> str:
-        return self._attr_preset_mode
-
+    
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
@@ -79,24 +79,76 @@ class MczFanEntity(CoordinatorEntity, FanEntity):
     @property
     def entity_category(self):
         return self._category
+      
+    @property
+    def available(self) -> bool:
+        return self._attr_available
+    
+    @property
+    def icon(self) -> str | None:
+        if(self._supported_fan is not None):
+           if(self._supported_fan.icon is not None and self.available == True):
+               return self._supported_fan.icon
+           elif(self._supported_fan.unavailable_icon is not None and self.available == False):
+               return self._supported_fan.unavailable_icon
+           else:
+               return None
+        else:
+            return None    
+
+    @property
+    def is_on(self) -> bool | None:
+        return self._attr_is_on
+    
+    @property
+    def percentage(self) -> int | None:
+        return self._attr_percentage
+
+    @property
+    def preset_mode(self) -> str | None:
+        return self._attr_preset_mode
+    
+    @property
+    def preset_modes(self) -> list[str] | None:
+        return self._attr_preset_modes
+    
+    @property
+    def speed_count(self) -> int:
+        return self._attr_speed_count
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
-        if(self._current_fan_configuration is not None):
-            await self.coordinator._maestroapi.ActivateProgram(self._current_fan_configuration.configuration.sensor_id, self._current_fan_configuration.configuration_id, int(preset_mode))
+        if(self._current_fan_configuration is not None and 
+           self._current_fan_configuration.configuration is not None and
+           self._current_fan_configuration.configuration.mappings is not None and
+           len(self._current_fan_configuration.configuration.mappings) > 0 and
+           preset_mode in self._current_fan_configuration.configuration.mappings):
+            await self.coordinator._maestroapi.ActivateProgram(self._current_fan_configuration.configuration.sensor_id, self._current_fan_configuration.configuration_id, preset_mode)
             await self.coordinator.update_data_after_set()
 
     async def async_turn_on(self, percentage: int | None = None, preset_mode: str | None = None, **kwargs: Any,) -> None:
         """Turn on the fan."""
-        if(self._current_fan_configuration is not None and self._presets is not None and len(self._presets) > 0):
-            await self.coordinator._maestroapi.ActivateProgram(self._current_fan_configuration.configuration.sensor_id, self._current_fan_configuration.configuration_id, int(self._presets[-1]))
-            await self.coordinator.update_data_after_set()
+        if(self._current_fan_configuration is not None):
+            if(preset_mode is not None):
+                await self.async_set_preset_mode(preset_mode)
+            elif(percentage is not None):
+                await self.async_set_percentage(percentage)
+            else:
+                await self.async_set_percentage(100)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
-        if(self._current_fan_configuration is not None and self._presets is not None and len(self._presets) > 0):
-            await self.coordinator._maestroapi.ActivateProgram(self._current_fan_configuration.configuration.sensor_id, self._current_fan_configuration.configuration_id, int(self._presets[0]))
+        if(self._current_fan_configuration is not None):
+            await self.coordinator._maestroapi.ActivateProgram(self._current_fan_configuration.configuration.sensor_id, self._current_fan_configuration.configuration_id, 0) # '0' means off
             await self.coordinator.update_data_after_set()
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the speed percentage of the fan."""
+        if(self._attr_speed_count > 1):
+            value_in_range = math.ceil(percentage_to_ranged_value((1, self._attr_speed_count), percentage))
+            if(self._current_fan_configuration is not None):
+                await self.coordinator._maestroapi.ActivateProgram(self._current_fan_configuration.configuration.sensor_id, self._current_fan_configuration.configuration_id, value_in_range)
+                await self.coordinator.update_data_after_set()
 
     def get_configuration_for_current_stove_mode(self) -> SensorConfiguration | None:
         """Get the correct sensor configuration for the current mode that the stove is in"""
@@ -105,37 +157,98 @@ class MczFanEntity(CoordinatorEntity, FanEntity):
             return self._fan_configuration.mode_configurations[self.coordinator._maestroapi.State.mode]
         return None
     
-    def update_features_based_on_current_stove_state(self) -> None:
+    def update_features_based_on_current_stove_mode(self) -> None:
         """Refresh all fan features that are applicable for the current mode that the stove is in"""
         self._current_fan_configuration = self.get_configuration_for_current_stove_mode()
 
         self._attr_supported_features = FanEntityFeature(0) # resetting the features
+        self._attr_preset_modes = None
+        self._attr_speed_count = 0
+        self._attr_available = False
+
         if(self._current_fan_configuration is not None and 
            self._current_fan_configuration.configuration is not None and 
            self._current_fan_configuration.configuration.enabled == True):
-            if(self._current_fan_configuration.configuration.type == TypeEnum.INT.value):
-                self._presets = self._attr_preset_modes = list(map(str,range(int(self._current_fan_configuration.configuration.min), int(self._current_fan_configuration.configuration.max) + 1 , 1)))
-                self._attr_supported_features = (FanEntityFeature.PRESET_MODE)
+                self._attr_available = True
+                if(self._current_fan_configuration.configuration.type == TypeEnum.INT.value):
+                    self._attr_speed_count = int(self._current_fan_configuration.configuration.max)
+                    self._attr_supported_features |= FanEntityFeature.SET_SPEED
+
+                    if(self._current_fan_configuration.configuration.variants is not None and 
+                        len(self._current_fan_configuration.configuration.variants) > 0):
+                            self._attr_preset_modes = []             
+                            for key in self._current_fan_configuration.configuration.variants:
+                                if key in self._current_fan_configuration.configuration.mappings.keys():
+                                    self._attr_preset_modes.append(key)         
+                            self._attr_supported_features |= FanEntityFeature.PRESET_MODE
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """handle coordinator updates"""
-        self.update_features_based_on_current_stove_state()
+        self.update_features_based_on_current_stove_mode()
         self.handle_coordinator_update_internal()
         self.async_write_ha_state()
 
     def handle_coordinator_update_internal(self) -> None:
         """handle coordinator updates for this fan"""
-        #presets
+        #determine silent mode is enabled 
+        if(self._supported_fan is not None and self._supported_fan.silent_enabled_get_name is not None):
+            if(hasattr(self.coordinator._maestroapi.State, self._supported_fan.silent_enabled_get_name)):
+                silent_enabled = bool(getattr(self.coordinator._maestroapi.State, self._supported_fan.silent_enabled_get_name))
+            elif(hasattr(self.coordinator._maestroapi.Status, self._supported_fan.silent_enabled_get_name)):
+                silent_enabled = bool(getattr(self.coordinator._maestroapi.Status, self._supported_fan.silent_enabled_get_name))
+            else:
+                silent_enabled = None
+
+            if(silent_enabled is not None and silent_enabled == True):
+                self._attr_available = False
+                return # we can return here since the rest doesn't matter anymore when the fan is not available    
+
+
+        #determine the fan value
         if(hasattr(self.coordinator._maestroapi.State, self._prop)):
-            self._attr_preset_mode = str(getattr(self.coordinator._maestroapi.State, self._prop))
+            fan_value = str(getattr(self.coordinator._maestroapi.State, self._prop))
         elif(hasattr(self.coordinator._maestroapi.Status, self._prop)):
-            self._attr_preset_mode = str(getattr(self.coordinator._maestroapi.Status, self._prop))
+            fan_value = str(getattr(self.coordinator._maestroapi.Status, self._prop))
+        else:
+            fan_value = None
+        
+        try:
+            fan_value = int(fan_value)
+        except Exception as ex:
+            pass # fan_value can be a string
+
+
+        # on/off
+        if(self._current_fan_configuration is not None and 
+           fan_value is not None and
+           (type(fan_value) is str or (type(fan_value) is int and fan_value != 0))):
+            self._attr_is_on = True
+        else:
+            self._attr_is_on = False
+
+        #presets
+        if(self._current_fan_configuration is not None and 
+           self._current_fan_configuration.configuration.mappings is not None and
+           len(self._current_fan_configuration.configuration.mappings) > 0 and
+           fan_value is not None and
+           ((type(fan_value) is str and fan_value in self._current_fan_configuration.configuration.mappings) or
+           (type(fan_value) is int and fan_value in self._current_fan_configuration.configuration.mappings.values() and fan_value != 0))):
+            if(type(fan_value) is str):
+                self._attr_preset_mode = fan_value
+            elif(type(fan_value) is int):
+                self._attr_preset_mode = self._current_fan_configuration.configuration.mappings[list(self._current_fan_configuration.configuration.mappings.values()).index(fan_value)]
         else:
             self._attr_preset_mode = None
 
-        # on/off
-        if(self._current_fan_configuration is not None and self._presets is not None and len(self._presets) > 0):
-            self._attr_is_on = self.preset_mode != self._presets[0]
+        #speed
+        if(self._current_fan_configuration is not None and 
+           self._current_fan_configuration.configuration.min is not None and
+           self._current_fan_configuration.configuration.max is not None and
+           fan_value is not None and
+           type(fan_value) is int and
+           int(self._current_fan_configuration.configuration.min) <= fan_value <= int(self._current_fan_configuration.configuration.max) and 
+           fan_value != 0):
+            self._attr_percentage = ranged_value_to_percentage((1, self._attr_speed_count),fan_value)
         else:
-            self._attr_is_on = False
+            self._attr_percentage = None

--- a/custom_components/maestro_mcz/models.py
+++ b/custom_components/maestro_mcz/models.py
@@ -20,6 +20,7 @@ class MczConfigItem:
     mode_to_configuration_name_mapping: dict[str,str] | None = None #key => Mode | value => Configuration Name
     user_friendly_name: str | None = None
     icon: str | None = None
+    unavailable_icon: str | None = None
     enabled_by_default: bool = True
     category: EntityCategory | None = None
 
@@ -63,13 +64,16 @@ class ThermostatMczConfigItem(MczConfigItem):
 
 @dataclass
 class FanMczConfigItem(MczConfigItem):
+    silent_enabled_get_name: str | None = None
 
-    def __init__(self, user_friendly_name:str, sensor_get_name:str, sensor_set_name:str, mode_to_configuration_name_mapping: dict[str,str], enabled_by_default: bool):
+    def __init__(self, user_friendly_name:str, sensor_get_name:str, sensor_set_name:str, mode_to_configuration_name_mapping: dict[str,str], silent_enabled_get_name: str | None , enabled_by_default: bool):
         super().__init__(user_friendly_name)
         self.sensor_get_name = sensor_get_name
         self.icon = "mdi:fan"
+        self.unavailable_icon = "mdi:fan-off"
         self.sensor_set_name = sensor_set_name
         self.mode_to_configuration_name_mapping = mode_to_configuration_name_mapping # means we want to find the sensor name in the different mode configs
+        self.silent_enabled_get_name = silent_enabled_get_name
         self.enabled_by_default = enabled_by_default
 
 @dataclass
@@ -194,12 +198,12 @@ supported_pots = [
 ]
 
 supported_fans = [
-    FanMczConfigItem("Fan 1", "set_vent_v1", "set_vent_v1", {"manual":"Manuale", "auto":"Auto", "overnight":"Overnight", "comfort":"Comfort", "turbo":"Turbo"}, True),
-    FanMczConfigItem("Fan 1", "set_vent_v1", "m1_set_vent_v1", {"manual":"Manuale","dynamic":"Dynamic", "overnight":"Overnight", "comfort":"Comfort", "power":"Power"}, True),  #for first generation M1+
-    FanMczConfigItem("Fan 2", "set_vent_v2", "set_vent_v2", {"manual":"Manuale", "auto":"Auto", "overnight":"Overnight", "comfort":"Comfort", "turbo":"Turbo"}, True),
-    FanMczConfigItem("Fan 2", "set_vent_v2", "m1_set_vent_v2", {"manual":"Manuale","dynamic":"Dynamic", "overnight":"Overnight", "comfort":"Comfort", "power":"Power"}, True),  #for first generation M1+
-    FanMczConfigItem("Fan 3", "set_vent_v3", "set_vent_v3", {"manual":"Manuale", "auto":"Auto", "overnight":"Overnight", "comfort":"Comfort", "turbo":"Turbo"}, True),
-    FanMczConfigItem("Fan 3", "set_vent_v3", "m1_set_vent_v3", {"manual":"Manuale","dynamic":"Dynamic", "overnight":"Overnight", "comfort":"Comfort", "power":"Power"}, True),  #for first generation M1+
+    FanMczConfigItem("Fan 1", "set_vent_v1", "set_vent_v1", {"manual":"Manuale", "auto":"Auto", "overnight":"Overnight", "comfort":"Comfort", "turbo":"Turbo"}, "silent_enabled", True),
+    FanMczConfigItem("Fan 1", "set_vent_v1", "m1_set_vent_v1", {"manual":"Manuale","dynamic":"Dynamic", "overnight":"Overnight", "comfort":"Comfort", "power":"Power"}, "silent_enabled", True),  #for first generation M1+
+    FanMczConfigItem("Fan 2", "set_vent_v2", "set_vent_v2", {"manual":"Manuale", "auto":"Auto", "overnight":"Overnight", "comfort":"Comfort", "turbo":"Turbo"}, "silent_enabled", True),
+    FanMczConfigItem("Fan 2", "set_vent_v2", "m1_set_vent_v2", {"manual":"Manuale","dynamic":"Dynamic", "overnight":"Overnight", "comfort":"Comfort", "power":"Power"}, "silent_enabled", True),  #for first generation M1+
+    FanMczConfigItem("Fan 3", "set_vent_v3", "set_vent_v3", {"manual":"Manuale", "auto":"Auto", "overnight":"Overnight", "comfort":"Comfort", "turbo":"Turbo"}, "silent_enabled", True),
+    FanMczConfigItem("Fan 3", "set_vent_v3", "m1_set_vent_v3", {"manual":"Manuale","dynamic":"Dynamic", "overnight":"Overnight", "comfort":"Comfort", "power":"Power"}, "silent_enabled", True),  #for first generation M1+
 ]
 
 supported_switches = [


### PR DESCRIPTION
We've added the proper fan speed and fan preset support as the documentation states 
=> https://developers.home-assistant.io/docs/core/entity/fan/#set-speed-percentage

NOTE: known limitation, once the silent mode preset is selected, there no way to turn it of again from within this integration. I'm planning to add an extra switch for the silent mode later...

Some previews:
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/6098925e-28b2-47f4-b422-764bae76ad1b)
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/cb98e56e-a325-4ffa-ab8e-ef3c42daaa0a)
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/e77160dc-08bf-463d-a2dd-a81177394fc8)
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/7997ce71-d886-40d6-b503-8424a2b8abc8)
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/27c47284-fff9-47f5-b0ea-119eff2bfd93)




