### PR TITLE
Adding support for a new "Last Alarm Code" sensor

### DIFF
--- a/custom_components/maestro_mcz/models.py
+++ b/custom_components/maestro_mcz/models.py
@@ -242,6 +242,7 @@ supported_binary_sensors = [
 ]
 
 supported_sensors = [
+    SensorMczConfigItem("Last Alarm Code","last_alarm","mdi:alert", None, None, EntityCategory.DIAGNOSTIC, None, None, True),
     SensorMczConfigItem("Current State","state","mdi:power", None, None, EntityCategory.DIAGNOSTIC, None, None, True),
     SensorMczConfigItem("Ambient Temperature","temp_amb_install","mdi:thermometer", UnitOfTemperature.CELSIUS, None, None, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),
     SensorMczConfigItem("Water Temperature","temp_caldaia","mdi:water-thermometer", UnitOfTemperature.CELSIUS, None, None, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),


### PR DESCRIPTION
Adding support for a new "Last Alarm Code" sensor:

![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/568340cc-74c9-4553-80d4-343d20c56274)
