### PR TITLE
Add Icons to preset modes of Climate and Fan entities

### DIFF
--- a/custom_components/maestro_mcz/climate.py
+++ b/custom_components/maestro_mcz/climate.py
@@ -38,6 +38,7 @@ class MczClimateEntity(CoordinatorEntity, ClimateEntity):
     _attr_current_temperature = None
     _attr_target_temperature = None
     _attr_preset_mode = None
+    _attr_translation_key: str = "main_climate"
 
     _supported_power_sensor: models.MczConfigItem | None = None
     _supported_thermostat: models.MczConfigItem | None = None

--- a/custom_components/maestro_mcz/fan.py
+++ b/custom_components/maestro_mcz/fan.py
@@ -46,6 +46,7 @@ class MczFanEntity(CoordinatorEntity, FanEntity):
     _attr_preset_mode: str | None = None
     _attr_preset_modes: list[str] | None = None
     _attr_speed_count: int = 0
+    _attr_translation_key: str = "main_fan"
     #
     _supported_fan: models.FanMczConfigItem | None = None
     _fan_configuration: SensorConfigurationMultipleModes | None = None

--- a/custom_components/maestro_mcz/icons.json
+++ b/custom_components/maestro_mcz/icons.json
@@ -1,0 +1,32 @@
+{
+    "entity": {
+      "climate": {
+        "main_climate": {
+          "state_attributes": {
+            "preset_mode": {
+              "default": "mdi:confused",
+              "state": {
+                "manual": "mdi:hand-back-right",
+                "auto": "mdi:thermometer-auto",
+                "overnight": "mdi:weather-night",
+                "comfort": "mdi:home-heart",
+                "turbo": "mdi:fire"
+              }
+            }
+          }
+        }
+      },
+      "fan": {
+        "main_fan": {
+          "state_attributes": {
+            "preset_mode": {
+              "state": {
+                "auto": "mdi:fan-auto",
+                "silent": "mdi:fan-off"
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/custom_components/maestro_mcz/strings.json
+++ b/custom_components/maestro_mcz/strings.json
@@ -25,5 +25,34 @@
         }
       }
     }
+  },
+  "entity": {
+    "climate": {
+      "main_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "manual": "Manual",
+              "auto": "Auto",
+              "overnight": "Overnight",
+              "comfort": "Comfort",
+              "turbo": "Turbo"
+            }
+          }
+        }
+      }
+    },
+    "fan": {
+      "main_fan": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto",
+              "silent": "Silent"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/maestro_mcz/translations/en.json
+++ b/custom_components/maestro_mcz/translations/en.json
@@ -25,5 +25,34 @@
                 }
             }
         }
+    },
+    "entity": {
+      "climate": {
+        "main_climate": {
+          "state_attributes": {
+            "preset_mode": {
+              "state": {
+                "manual": "Manual",
+                "auto": "Auto",
+                "overnight": "Overnight",
+                "comfort": "Comfort",
+                "turbo": "Turbo"
+              }
+            }
+          }
+        }
+      },
+      "fan": {
+        "main_fan": {
+          "state_attributes": {
+            "preset_mode": {
+              "state": {
+                "auto": "Auto",
+                "silent": "Silent"
+              }
+            }
+          }
+        }
+      }
     }
 }

--- a/custom_components/maestro_mcz/translations/nl.json
+++ b/custom_components/maestro_mcz/translations/nl.json
@@ -25,5 +25,34 @@
                 }
             }
         }
+    },
+    "entity": {
+      "climate": {
+        "main_climate": {
+          "state_attributes": {
+            "preset_mode": {
+              "state": {
+                "manual": "Manual",
+                "auto": "Auto",
+                "overnight": "Overnight",
+                "comfort": "Comfort",
+                "turbo": "Turbo"
+              }
+            }
+          }
+        }
+      },
+      "fan": {
+        "main_fan": {
+          "state_attributes": {
+            "preset_mode": {
+              "state": {
+                "auto": "Auto",
+                "silent": "Silent"
+              }
+            }
+          }
+        }
+      }
     }
 }


### PR DESCRIPTION
We've added new icons for the preset modes of Climate and Fan entities.
According to https://developers.home-assistant.io/docs/core/entity/#icons
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/501ed4b9-79f6-470d-ac6f-1d92f4f2f3f9)
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/ce78153e-c6f2-44e0-9b7b-ca0be2caddf3)
