### PR TITLE
Fix power state of the stove for some older models

### DIFF
--- a/custom_components/maestro_mcz/climate.py
+++ b/custom_components/maestro_mcz/climate.py
@@ -170,16 +170,17 @@ class MczClimateEntity(CoordinatorEntity, ClimateEntity):
     def handle_coordinator_update_internal(self) -> None:
         #HVAC mode
         if(self._supported_power_sensor is not None): 
-            fase_op = getattr(self.coordinator._maestroapi.Status, self._supported_power_sensor.sensor_get_name)
-            if(fase_op is not None):
-                if(str(fase_op).lower() == "on" or str(fase_op).lower() == "turning-on"):
-                    self._attr_hvac_mode = HVACMode.HEAT
-                else: # turning-off | off | cooling-down
+            stato_stufa = getattr(self.coordinator._maestroapi.Status, self._supported_power_sensor.sensor_get_name)
+            if(stato_stufa is not None):
+                if(stato_stufa == 1):
                     self._attr_hvac_mode = HVACMode.OFF
+                else:
+                    self._attr_hvac_mode = HVACMode.HEAT
             else:
                 self._attr_hvac_mode = HVACMode.OFF
         else:
             self._attr_hvac_mode = None
+            
 
         #current temp
         self._attr_current_temperature = self.coordinator._maestroapi.State.temp_amb_install

--- a/custom_components/maestro_mcz/manifest.json
+++ b/custom_components/maestro_mcz/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/Robbe-B/maestro_mcz/issues",
     "requirements": [],
-    "version": "0.4.2-beta"
+    "version": "0.5.3-beta"
 }

--- a/custom_components/maestro_mcz/models.py
+++ b/custom_components/maestro_mcz/models.py
@@ -174,8 +174,8 @@ class SensorMczConfigItem(MczConfigItem):
         self.api_value_renames = api_value_renames
 
 supported_power_settings = [
-    PowerSettingMczConfigItem("Power", "fase_op", "com_on_off", "Spegnimento", True),
-    PowerSettingMczConfigItem("Power", "fase_op", "m1_stato_stufa", "Spegnimento", True), #for first generation M1+
+    PowerSettingMczConfigItem("Power", "stato_stufa", "com_on_off", "Spegnimento", True),
+    PowerSettingMczConfigItem("Power", "stato_stufa", "m1_stato_stufa", "Spegnimento", True), #for first generation M1+
 ]
 
 supported_climate_function_modes = [


### PR DESCRIPTION
We've changed the stove power detection to one unified way for all stove models.
Up to now, I'm not aware of any side effects on other models.