### PR TITLE
Add date time support for stove clock

### DIFF
--- a/custom_components/maestro_mcz/__init__.py
+++ b/custom_components/maestro_mcz/__init__.py
@@ -27,7 +27,7 @@ from .maestro.controller.maestro_controller import MaestroController
 from .maestro.controller.mocked_controller import MockedController
 
 
-PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SENSOR, Platform.FAN, Platform.NUMBER, Platform.SWITCH, Platform.SELECT, Platform.BINARY_SENSOR, Platform.BUTTON]
+PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SENSOR, Platform.FAN, Platform.NUMBER, Platform.SWITCH, Platform.SELECT, Platform.BINARY_SENSOR, Platform.BUTTON, Platform.DATETIME]
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/maestro_mcz/datetime.py
+++ b/custom_components/maestro_mcz/datetime.py
@@ -1,0 +1,267 @@
+"""Platform for DateTime integration."""
+import homeassistant.util.dt as dt_util
+from datetime import UTC, datetime
+
+from . import MczCoordinator, models
+from ..maestro_mcz.maestro.responses.model import SensorConfiguration
+from ..maestro_mcz.maestro.types.enums import TypeEnum
+from ..maestro_mcz.maestro.http.request import MczProgramCommand
+
+
+from homeassistant.components.datetime import DateTimeEntity
+from homeassistant.core import callback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from .const import DOMAIN
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    stoveList = hass.data[DOMAIN][entry.entry_id]
+    entities = []
+    for stove in stoveList:
+        stove:MczCoordinator = stove
+        supported_date_times = stove.get_all_matching_sensor_configurations_by_model_configuration_name_and_sensor_name(models.supported_date_times)
+        if(supported_date_times is not None):
+            for supported_date_time in supported_date_times:
+                if(supported_date_time[0] is not None and supported_date_time[1] is not None):
+                    entities.append(MczDateTimeEntity(stove, supported_date_time[0], supported_date_time[1]))
+
+    async_add_entities(entities)
+
+
+class MczDateTimeEntity(CoordinatorEntity, DateTimeEntity):
+    """Representation of a date/time entity."""
+
+    _attr_has_entity_name = True
+    _attr_native_value = None
+    _attr_am_pm = None
+    _attr_weekday = None
+
+    _supported_date_time_sensor: models.DateTimeMczConfigItem | None = None
+    #
+    _date_time_configuration: SensorConfiguration | None = None
+
+    _sensor_configuration_weekday: SensorConfiguration | None = None
+    _sensor_configuration_year: SensorConfiguration | None = None
+    _sensor_configuration_month: SensorConfiguration | None = None
+    _sensor_configuration_day: SensorConfiguration | None = None
+    _sensor_configuration_hour: SensorConfiguration | None = None
+    _sensor_configuration_minute: SensorConfiguration | None = None
+    _sensor_configuration_second: SensorConfiguration | None = None
+    _sensor_configuration_am_pm: SensorConfiguration | None = None
+
+
+    def __init__(self, coordinator:MczCoordinator, supported_date_time: models.DateTimeMczConfigItem, matching_date_time_configuration: SensorConfiguration) -> None:
+        """Initialize the date/time entity."""
+        super().__init__(coordinator)
+        self.coordinator:MczCoordinator = coordinator
+        self._attr_name = supported_date_time.user_friendly_name
+        self._attr_unique_id = f"{self.coordinator._maestroapi.Status.sm_sn}-{supported_date_time.sensor_set_name}"
+        self._attr_icon = supported_date_time.icon
+        self._prop = supported_date_time.sensor_set_name
+        self._enabled_default = supported_date_time.enabled_by_default
+        self._category = supported_date_time.category
+
+        self._supported_date_time_sensor = supported_date_time
+        self.set_date_time_configuration(matching_date_time_configuration)
+
+        self.handle_coordinator_update_internal() #getting the initial update directly without delay
+
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return self.coordinator.get_device_info()
+    
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        return self._enabled_default
+
+    @property
+    def entity_category(self):
+        return self._category
+    
+    @property
+    def native_value(self) -> datetime | None:
+        return self._attr_native_value
+    
+    @property
+    def am_pm(self) -> bool | None:
+        return self._attr_am_pm
+    
+    @property
+    def weekday(self) -> int | None:
+        return self._attr_weekday
+    
+    def set_date_time_configuration(self, matching_date_time_configuration: SensorConfiguration):
+        self._date_time_configuration = matching_date_time_configuration
+
+        if(self._supported_date_time_sensor.sensor_set_config_name is not None):
+            #set weekday config 
+            if(self._supported_date_time_sensor.sensor_set_name is not None):
+                supported_sensor_weekday = self.coordinator.get_sensor_configuration_by_model_configuration_name_and_sensor_name(self._supported_date_time_sensor.sensor_set_config_name, self._supported_date_time_sensor.sensor_set_name_weekday)
+                if(supported_sensor_weekday is not None and 
+                   supported_sensor_weekday.configuration is not None and 
+                   supported_sensor_weekday.configuration.type == TypeEnum.INT.value):
+                    self._sensor_configuration_weekday = supported_sensor_weekday
+            #set year config 
+            if(self._supported_date_time_sensor.sensor_set_name_year is not None):
+                supported_sensor_year = self.coordinator.get_sensor_configuration_by_model_configuration_name_and_sensor_name(self._supported_date_time_sensor.sensor_set_config_name, self._supported_date_time_sensor.sensor_set_name_year)
+                if(supported_sensor_year is not None and 
+                   supported_sensor_year.configuration is not None and 
+                   supported_sensor_year.configuration.type == TypeEnum.INT.value):
+                    self._sensor_configuration_year = supported_sensor_year
+            #set month config 
+            if(self._supported_date_time_sensor.sensor_set_name_month is not None):
+                supported_sensor_month = self.coordinator.get_sensor_configuration_by_model_configuration_name_and_sensor_name(self._supported_date_time_sensor.sensor_set_config_name, self._supported_date_time_sensor.sensor_set_name_month)
+                if(supported_sensor_month is not None and
+                   supported_sensor_month.configuration is not None and
+                   supported_sensor_month.configuration.type == TypeEnum.INT.value):
+                    self._sensor_configuration_month = supported_sensor_month
+            #set day config 
+            if(self._supported_date_time_sensor.sensor_set_name_day is not None):
+                supported_sensor_day = self.coordinator.get_sensor_configuration_by_model_configuration_name_and_sensor_name(self._supported_date_time_sensor.sensor_set_config_name, self._supported_date_time_sensor.sensor_set_name_day)
+                if(supported_sensor_day is not None and 
+                   supported_sensor_day.configuration is not None and
+                   supported_sensor_day.configuration.type == TypeEnum.INT.value):
+                    self._sensor_configuration_day = supported_sensor_day
+            #set hour config 
+            if(self._supported_date_time_sensor.sensor_set_name_hour is not None):
+                supported_sensor_hour = self.coordinator.get_sensor_configuration_by_model_configuration_name_and_sensor_name(self._supported_date_time_sensor.sensor_set_config_name, self._supported_date_time_sensor.sensor_set_name_hour)
+                if(supported_sensor_hour is not None and 
+                   supported_sensor_hour.configuration is not None and 
+                   supported_sensor_hour.configuration.type == TypeEnum.INT.value):
+                    self._sensor_configuration_hour = supported_sensor_hour
+            #set minute config 
+            if(self._supported_date_time_sensor.sensor_set_name_minute is not None):
+                supported_sensor_minute = self.coordinator.get_sensor_configuration_by_model_configuration_name_and_sensor_name(self._supported_date_time_sensor.sensor_set_config_name, self._supported_date_time_sensor.sensor_set_name_minute)
+                if(supported_sensor_minute is not None and
+                   supported_sensor_minute.configuration is not None and
+                   supported_sensor_minute.configuration.type == TypeEnum.INT.value):
+                    self._sensor_configuration_minute = supported_sensor_minute
+            #set second config 
+            if(self._supported_date_time_sensor.sensor_set_name_second is not None):
+                supported_sensor_second = self.coordinator.get_sensor_configuration_by_model_configuration_name_and_sensor_name(self._supported_date_time_sensor.sensor_set_config_name, self._supported_date_time_sensor.sensor_set_name_second)
+                if(supported_sensor_second is not None and
+                   supported_sensor_second.configuration is not None and
+                   supported_sensor_second.configuration.type == TypeEnum.INT.value):
+                    self._sensor_configuration_second = supported_sensor_second
+            #set am pm config 
+            if(self._supported_date_time_sensor.sensor_set_name_am_pm is not None):
+                supported_sensor_am_pm = self.coordinator.get_sensor_configuration_by_model_configuration_name_and_sensor_name(self._supported_date_time_sensor.sensor_set_config_name, self._supported_date_time_sensor.sensor_set_name_am_pm)
+                if(supported_sensor_am_pm is not None and
+                   supported_sensor_am_pm.configuration is not None and
+                   supported_sensor_am_pm.configuration.type == TypeEnum.BOOLEAN.value):
+                    self._sensor_configuration_am_pm = supported_sensor_am_pm
+    
+    async def async_set_value(self, value: datetime) -> None:
+        """Update the date/time."""
+        list_of_commands: list[MczProgramCommand] = []
+        converted_to_timezone = value.astimezone(dt_util.DEFAULT_TIME_ZONE)
+        if(converted_to_timezone is not None):
+            if(self._date_time_configuration is not None):
+                if(self._sensor_configuration_weekday is not None and 
+                self._sensor_configuration_weekday.configuration.type == TypeEnum.INT.value):
+                    list_of_commands.append(MczProgramCommand(self._sensor_configuration_weekday.configuration.sensor_id, converted_to_timezone.weekday()))
+                if(self._sensor_configuration_year is not None and 
+                self._sensor_configuration_year.configuration.type == TypeEnum.INT.value):
+                    list_of_commands.append(MczProgramCommand(self._sensor_configuration_year.configuration.sensor_id, converted_to_timezone.year))
+                if(self._sensor_configuration_month is not None and 
+                self._sensor_configuration_month.configuration.type == TypeEnum.INT.value):
+                    list_of_commands.append(MczProgramCommand(self._sensor_configuration_month.configuration.sensor_id, converted_to_timezone.month))
+                if(self._sensor_configuration_day is not None and 
+                self._sensor_configuration_day.configuration.type == TypeEnum.INT.value):
+                    list_of_commands.append(MczProgramCommand(self._sensor_configuration_day.configuration.sensor_id, converted_to_timezone.day))
+                if(self._sensor_configuration_hour is not None and 
+                self._sensor_configuration_hour.configuration.type == TypeEnum.INT.value):
+                    list_of_commands.append(MczProgramCommand(self._sensor_configuration_hour.configuration.sensor_id, converted_to_timezone.hour))
+                if(self._sensor_configuration_minute is not None and 
+                self._sensor_configuration_minute.configuration.type == TypeEnum.INT.value):
+                    list_of_commands.append(MczProgramCommand(self._sensor_configuration_minute.configuration.sensor_id, converted_to_timezone.minute))
+                if(self._sensor_configuration_second is not None and 
+                self._sensor_configuration_second.configuration.type == TypeEnum.INT.value):
+                    list_of_commands.append(MczProgramCommand(self._sensor_configuration_second.configuration.sensor_id, converted_to_timezone.second))
+                if(self._sensor_configuration_am_pm is not None and 
+                self._sensor_configuration_am_pm.configuration.type == TypeEnum.BOOLEAN.value):
+                    list_of_commands.append(MczProgramCommand(self._sensor_configuration_am_pm.configuration.sensor_id, self.am_pm))
+                
+
+                await self.coordinator._maestroapi.ActivateProgramMultipleCommands(self._date_time_configuration.configuration_id, list_of_commands)
+
+                await self.coordinator.update_data_after_set()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self.handle_coordinator_update_internal()
+        self.async_write_ha_state()
+
+    def handle_coordinator_update_internal(self) -> None:
+
+        weekday: int | None = None
+        year: int | None = None
+        month: int | None = None
+        day: int | None = None
+        hour: int | None = None
+        minute: int | None = None
+        second: int | None = None
+        am_pm: bool | None = None
+         
+        if(self._supported_date_time_sensor is not None): 
+            if(self._sensor_configuration_weekday is not None and 
+               hasattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_weekday)):
+                weekday = getattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_weekday)
+            if(self._sensor_configuration_year is not None and 
+               hasattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_year)):
+                year = getattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_year)
+            if(self._sensor_configuration_month is not None and 
+               hasattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_month)):
+                month = getattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_month)
+            if(self._sensor_configuration_day is not None and 
+               hasattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_day)):
+                day = getattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_day)
+            if(self._sensor_configuration_hour is not None and 
+               hasattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_hour)):
+                hour = getattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_hour)
+            if(self._sensor_configuration_minute is not None and 
+               hasattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_minute)):
+                minute = getattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_minute)
+            if(self._sensor_configuration_second is not None and
+               hasattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_second)):
+                second = getattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_second)
+            if(self._sensor_configuration_am_pm is not None and 
+               hasattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_am_pm)):
+                am_pm = getattr(self.coordinator._maestroapi.Status, self._supported_date_time_sensor.sensor_get_name_am_pm)
+
+        if(weekday is not None):
+           self._attr_weekday = weekday
+        else: 
+            self._attr_weekday = None
+
+        if(year is not None and 
+           month is not None and
+           day is not None and
+           hour is not None and
+           minute is not None): 
+            if(second is None):
+                second = 0
+                
+            self._attr_native_value = datetime(
+                year=year,
+                month=month,
+                day=day,
+                hour=hour,
+                minute=minute,
+                second=second,
+                tzinfo=dt_util.DEFAULT_TIME_ZONE,
+            )        
+        else:     
+            self._attr_native_value = None
+            
+        
+        if(am_pm is not None):
+             self._attr_am_pm = am_pm
+        else: 
+            self._attr_am_pm = None
+
+    
+
+

--- a/custom_components/maestro_mcz/maestro/http/request.py
+++ b/custom_components/maestro_mcz/maestro/http/request.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 def RequestBuilder(self, ConfigurationId: str, Commands: str):
     return  {
                 "ModelId": self.ModelId,
@@ -5,3 +7,12 @@ def RequestBuilder(self, ConfigurationId: str, Commands: str):
                 "SensorSetTypeId":self.SensorSetTypeId,
                 "Commands":Commands
             }
+
+@dataclass
+class MczProgramCommand:
+    SensorId: str | None = None
+    Value: object | None = None
+
+    def __init__(self, sensor_id: str | None, value: object | None ) -> None:
+        self.SensorId = sensor_id
+        self.Value = value

--- a/custom_components/maestro_mcz/manifest.json
+++ b/custom_components/maestro_mcz/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/Robbe-B/maestro_mcz/issues",
     "requirements": [],
-    "version": "0.5.4-beta"
+    "version": "0.5.5-beta"
 }

--- a/custom_components/maestro_mcz/models.py
+++ b/custom_components/maestro_mcz/models.py
@@ -133,6 +133,69 @@ class SelectMczConfigItem(MczConfigItem):
         self.value_mappings = value_mappings
 
 @dataclass
+class DateTimeMczConfigItem(MczConfigItem):
+    
+    sensor_set_name_weekday: str | None = None
+    sensor_get_name_weekday: str | None = None
+
+    sensor_set_name_year: str | None = None
+    sensor_get_name_year: str | None = None
+
+    sensor_set_name_month: str | None = None
+    sensor_get_name_month: str | None = None
+
+    sensor_set_name_day: str | None = None
+    sensor_get_name_day: str | None = None
+
+    sensor_set_name_hour: str | None = None
+    sensor_get_name_hour: str | None = None
+
+    sensor_set_name_minute: str | None = None
+    sensor_get_name_minute: str | None = None
+
+    sensor_set_name_second: str | None = None
+    sensor_get_name_second: str | None = None
+
+    sensor_set_name_am_pm: str | None = None
+    sensor_get_name_am_pm: str | None = None
+
+
+
+    def __init__(self, user_friendly_name:str, sensor_get_name:str, sensor_set_name:str,
+                sensor_get_name_weekday:str, sensor_set_name_weekday:str, 
+                sensor_get_name_year:str, sensor_set_name_year:str,
+                sensor_get_name_month:str, sensor_set_name_month:str,
+                sensor_get_name_day:str, sensor_set_name_day:str,
+                sensor_get_name_hour:str, sensor_set_name_hour:str,
+                sensor_get_name_minute:str, sensor_set_name_minute:str,
+                sensor_get_name_second:str, sensor_set_name_second:str,
+                sensor_get_name_am_pm:str, sensor_set_name_am_pm:str,
+                sensor_set_config_name:str, icon:str, category: EntityCategory | None, enabled_by_default: bool):
+        super().__init__(user_friendly_name)
+        self.sensor_get_name = sensor_get_name
+        self.sensor_get_name_weekday = sensor_get_name_weekday
+        self.sensor_get_name_year = sensor_get_name_year
+        self.sensor_get_name_month = sensor_get_name_month
+        self.sensor_get_name_day = sensor_get_name_day
+        self.sensor_get_name_hour = sensor_get_name_hour
+        self.sensor_get_name_minute = sensor_get_name_minute
+        self.sensor_get_name_second = sensor_get_name_second
+        self.sensor_get_name_am_pm = sensor_get_name_am_pm
+        self.icon = icon
+        self.category = category
+        self.sensor_set_name = sensor_set_name
+        self.sensor_set_name_weekday = sensor_set_name_weekday
+        self.sensor_set_name_year = sensor_set_name_year
+        self.sensor_set_name_month = sensor_set_name_month
+        self.sensor_set_name_day = sensor_set_name_day
+        self.sensor_set_name_hour = sensor_set_name_hour
+        self.sensor_set_name_minute = sensor_set_name_minute
+        self.sensor_set_name_second = sensor_set_name_second
+        self.sensor_set_config_name = sensor_set_config_name
+        self.sensor_set_name_am_pm = sensor_set_name_am_pm
+        self.enabled_by_default = enabled_by_default
+
+@dataclass
 class PotMczConfigItem(SelectMczConfigItem):
 
     def __init__(self, user_friendly_name:str, sensor_get_name:str, sensor_set_name:str, sensor_set_config_name:str, enabled_by_default: bool):
@@ -230,6 +293,31 @@ supported_numbers = [
 supported_selectors = [
     SelectMczConfigItem("Tones", "toni_buzz", "toni_buzz", "Toni", "mdi:volume-high", EntityCategory.CONFIG, True, {"0":"Silent", "1":"Normal", "2":"High"}),
     SelectMczConfigItem("Tones", "toni_buzz", "m1_toni_buzz", "Toni", "mdi:volume-high", EntityCategory.CONFIG, True, {"0":"Silent", "1":"Normal", "2":"High"}), #for first generation M1+
+]
+
+supported_date_times = [
+    DateTimeMczConfigItem("Date & Time",
+                          "giorno", "giorno",
+                          "giorno_sett", "giorno_sett",
+                          "anno", "anno",
+                          "mese", "mese",
+                          "giorno", "giorno",
+                          "ore", "ore",
+                          "minuti", "minuti",
+                          "secondi", "secondi",
+                          "am_pm","am_pm",
+                          "Orodatario", "mdi:calendar-clock", EntityCategory.CONFIG, False),
+    DateTimeMczConfigItem("Date & Time",
+                          "giorno", "m1_giorno",
+                          None, None,
+                          "anno", "m1_anno",
+                          "mese", "m1_mese",
+                          "giorno", "m1_giorno",
+                          "ore", "m1_ore",
+                          "minuti", "m1_minuti",
+                          None, None,
+                          None, None,
+                          "Orodatario", "mdi:calendar-clock", EntityCategory.CONFIG, False),  #for first generation M1+                   
 ]
 
 supported_buttons = [


### PR DESCRIPTION
We've added support for a new date & time entity in order to set the date and time on your stove.
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/de2f4279-2716-442d-8aa7-fd35ce33baf3)

NOTE: This entity is disabled by default since it generates lot's of logbook items:
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/e5b7b19a-7d1f-4f84-8f3f-beca7dd840b6)
I'm still looking for a solution in order to turn of the "recorders" for this entity. 
This can be done via configuration in HA itself but not through the integration itself at this point. 
We might request this as a feature for HA core.
But for now it's functional when you need it, you can enable / disable the entity yourself.