### PR TITLE
Fix: Some entities not showing up

### DIFF
--- a/custom_components/maestro_mcz/__init__.py
+++ b/custom_components/maestro_mcz/__init__.py
@@ -136,7 +136,7 @@ class MczCoordinator(DataUpdateCoordinator):
         )
     
     def get_model_configuration_by_model_configuration_name(self, model_configuration_name:str) -> ModelConfiguration | None:
-        return next((x for x in self._maestroapi.Model.model_configurations if x.configuration_name is not None and model_configuration_name is not None and x.configuration_name.lower() == model_configuration_name.lower()), None)
+        return next((x for x in self._maestroapi.Model.model_configurations if x.configuration_name is not None and model_configuration_name is not None and x.configuration_name.lower().strip() == model_configuration_name.lower().strip()), None)
     
             
     def get_sensor_configuration_by_model_configuration_name_and_sensor_name(self, model_configuration_name:str, sensor_name:str) -> SensorConfiguration | None:
@@ -144,7 +144,7 @@ class MczCoordinator(DataUpdateCoordinator):
         if(model_configuration is None):
             return None
         else:
-            sensor_configuration = next((x for x in model_configuration.configurations if x.sensor_name is not None and sensor_name is not None and x.sensor_name.lower() == sensor_name.lower()), None)
+            sensor_configuration = next((x for x in model_configuration.configurations if x.sensor_name is not None and sensor_name is not None and x.sensor_name.lower().strip() == sensor_name.lower().strip()), None)
             if(sensor_configuration is not None):
                 return SensorConfiguration(sensor_configuration, model_configuration.configuration_id)
 


### PR DESCRIPTION
Fix: Some entities of the stove are not showing up due to spaces in the configuration en sensor names.
We made sure to trim these spaces out before dynamically searching in the configuration of the stove.