### PR TITLE
Fix missing Start / Stop entities for m1 models

### DIFF
--- a/custom_components/maestro_mcz/models.py
+++ b/custom_components/maestro_mcz/models.py
@@ -279,12 +279,14 @@ supported_switches = [
 
 supported_numbers = [
     #start/stop
-    NumberMczConfigItem("Start / Stop - Delay in Ignition", "rit_usc_standby", "rit_usc_standby", "Start&Stop", "auto", "mdi:fire", UnitOfTime.SECONDS ,EntityCategory.CONFIG, None, True),    
+    NumberMczConfigItem("Start / Stop - Delay in Ignition", "rit_usc_standby", "rit_usc_standby", "Start&Stop", "auto", "mdi:fire", UnitOfTime.SECONDS ,EntityCategory.CONFIG, None, True),
+    NumberMczConfigItem("Start / Stop - Delay in Ignition", "rit_usc_standby", "m1_rit_usc_standby", "Start&Stop", "auto", "mdi:fire", UnitOfTime.SECONDS ,EntityCategory.CONFIG, None, True), #for first generation M1+ 
     NumberMczConfigItem("Start / Stop - Delay in Shutdown", "rit_ing_standby", "rit_ing_standby", "Start&Stop", "auto", "mdi:fire-off", UnitOfTime.SECONDS ,EntityCategory.CONFIG, None, True), 
     NumberMczConfigItem("Start / Stop - Delay in Shutdown", "rit_ing_standby", "m1_rit_ing_standby", "Start&Stop", "auto", "mdi:fire-off", UnitOfTime.SECONDS ,EntityCategory.CONFIG, None, True), #for first generation M1+ 
     NumberMczConfigItem("Start / Stop - Negative Hysteresis", "ist_eco_neg_amb", "ist_eco_neg_amb", "Start&Stop", "auto", "mdi:thermometer-minus", UnitOfTemperature.CELSIUS ,EntityCategory.CONFIG, NumberDeviceClass.TEMPERATURE, True),
     NumberMczConfigItem("Start / Stop - Negative Hysteresis", "ist_eco_neg_amb", "m1_ist_eco_neg_amb", "Start&Stop", "auto", "mdi:thermometer-minus", UnitOfTemperature.CELSIUS ,EntityCategory.CONFIG, NumberDeviceClass.TEMPERATURE, True),  #for first generation M1+
-    NumberMczConfigItem("Start / Stop - Positive Hysteresis", "ist_eco_pos_amb", "ist_eco_pos_amb", "Start&Stop", "auto", "mdi:thermometer-plus", UnitOfTemperature.CELSIUS ,EntityCategory.CONFIG, NumberDeviceClass.TEMPERATURE, True),  
+    NumberMczConfigItem("Start / Stop - Positive Hysteresis", "ist_eco_pos_amb", "ist_eco_pos_amb", "Start&Stop", "auto", "mdi:thermometer-plus", UnitOfTemperature.CELSIUS ,EntityCategory.CONFIG, NumberDeviceClass.TEMPERATURE, True),
+    NumberMczConfigItem("Start / Stop - Positive Hysteresis", "ist_eco_pos_amb", "m1_ist_eco_pos_amb", "Start&Stop", "auto", "mdi:thermometer-plus", UnitOfTemperature.CELSIUS ,EntityCategory.CONFIG, NumberDeviceClass.TEMPERATURE, True), #for first generation M1+  
     #ambient
     NumberMczConfigItem("Ambient - Negative Hysteresis", "ist_neg_amb", "ist_neg_amb", "Ambiente", "auto", "mdi:thermometer-minus", UnitOfTemperature.CELSIUS ,EntityCategory.CONFIG, NumberDeviceClass.TEMPERATURE, True),
     NumberMczConfigItem("Ambient - Positive Hysteresis", "ist_pos_amb", "ist_pos_amb", "Ambiente", "auto", "mdi:thermometer-plus", UnitOfTemperature.CELSIUS ,EntityCategory.CONFIG, NumberDeviceClass.TEMPERATURE, True),


### PR DESCRIPTION
For some M1 models, not all supported Start / Stop settings were shown => Fixed