### PR TITLE
Add support for system date and time sync button

### DIFF
--- a/custom_components/maestro_mcz/binary_sensor.py
+++ b/custom_components/maestro_mcz/binary_sensor.py
@@ -31,7 +31,7 @@ class MczBinarySensorEntity(CoordinatorEntity, BinarySensorEntity):
     _attr_has_entity_name = True
     _attr_is_on = None
 
-    def __init__(self, coordinator, supported_binary_sensor: models.BinarySensorMczConfigItem):
+    def __init__(self, coordinator, supported_binary_sensor: models.BinarySensorMczConfigItem) -> None:
         super().__init__(coordinator)
         self.coordinator:MczCoordinator = coordinator
         self._attr_name = supported_binary_sensor.user_friendly_name

--- a/custom_components/maestro_mcz/button.py
+++ b/custom_components/maestro_mcz/button.py
@@ -1,8 +1,10 @@
 """Platform for Button integration."""
+from ..maestro_mcz.datetime import MczDateTimeEntity
 from ..maestro_mcz.maestro.responses.model import SensorConfiguration
 from ..maestro_mcz.maestro.types.enums import TypeEnum
 from . import MczCoordinator, models
 
+from homeassistant.util import dt as dt_util
 from homeassistant.components.button import (
     ButtonEntity,
 )
@@ -18,11 +20,20 @@ async def async_setup_entry(hass, entry, async_add_entities):
     entities = []
     for stove in stoveList:
         stove:MczCoordinator = stove
+
+        #buttons
         supported_buttons = stove.get_all_matching_sensor_configurations_by_model_configuration_name_and_sensor_name(models.supported_buttons)
         if(supported_buttons is not None):
             for supported_button in supported_buttons:
                 if(supported_button[0] is not None and supported_button[1] is not None):
                     entities.append(MczButtonEntity(stove, supported_button[0], supported_button[1]))
+
+        #time sync buttons 
+        supported_time_sync_buttons = stove.get_all_matching_sensor_configurations_by_model_configuration_name_and_sensor_name(models.supported_time_sync_buttons)
+        if(supported_time_sync_buttons is not None):
+            for supported_time_sync_button in supported_time_sync_buttons:
+                if(supported_time_sync_button[0] is not None and supported_time_sync_button[1] is not None):
+                    entities.append(MczTimeSyncButtonEntity(stove, supported_time_sync_button[0], supported_time_sync_button[1]))
 
 
     async_add_entities(entities)
@@ -35,7 +46,7 @@ class MczButtonEntity(CoordinatorEntity, ButtonEntity):
     #
     _button_configuration: SensorConfiguration | None = None
 
-    def __init__(self, coordinator, supported_button: models.ButtonMczConfigItem, matching_button_configuration: SensorConfiguration):
+    def __init__(self, coordinator, supported_button: models.ButtonMczConfigItem, matching_button_configuration: SensorConfiguration) -> None:
         super().__init__(coordinator)
         self.coordinator:MczCoordinator = coordinator
         self._attr_name = supported_button.user_friendly_name
@@ -50,6 +61,14 @@ class MczButtonEntity(CoordinatorEntity, ButtonEntity):
     @property
     def device_info(self) -> DeviceInfo:
         return self.coordinator.get_device_info()
+    
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        return self._enabled_default
+
+    @property
+    def entity_category(self):
+        return self._category
     
     def set_button_configuration(self, matching_button_configuration: SensorConfiguration):
         self._button_configuration = matching_button_configuration
@@ -73,6 +92,37 @@ class MczButtonEntity(CoordinatorEntity, ButtonEntity):
                 await self.coordinator._maestroapi.ActivateProgram(self._button_configuration.configuration.sensor_id, self._button_configuration.configuration_id, int(self._attr_return_value))
                 await self.coordinator.update_data_after_set()
 
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self.async_write_ha_state()
+
+
+class MczTimeSyncButtonEntity(CoordinatorEntity, ButtonEntity):
+     
+    _attr_has_entity_name = True
+    #
+    _time_sync_button_configuration: SensorConfiguration | None = None
+    _mczDateTimeEntity: MczDateTimeEntity | None = None
+    
+    def __init__(self, coordinator, supported_time_sync_button: models.TimeSyncButtonMczConfigItem, matching_time_sync_button_configuration: SensorConfiguration) -> None:
+        super().__init__(coordinator)
+        self.coordinator:MczCoordinator = coordinator
+
+        self._mczDateTimeEntity = MczDateTimeEntity(coordinator, supported_time_sync_button, matching_time_sync_button_configuration)
+
+        self._attr_name = supported_time_sync_button.user_friendly_name
+        self._attr_unique_id = f"{self.coordinator._maestroapi.Status.sm_sn}-{supported_time_sync_button.sensor_set_name}"
+        self._attr_icon = supported_time_sync_button.icon
+        self._prop = supported_time_sync_button.sensor_set_name
+        self._enabled_default = supported_time_sync_button.enabled_by_default
+        self._category = supported_time_sync_button.category
+
+        self.set_time_sync_button_configuration(matching_time_sync_button_configuration)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return self.coordinator.get_device_info()
+    
     @property
     def entity_registry_enabled_default(self) -> bool:
         return self._enabled_default
@@ -80,6 +130,21 @@ class MczButtonEntity(CoordinatorEntity, ButtonEntity):
     @property
     def entity_category(self):
         return self._category
+    
+    def set_time_sync_button_configuration(self, matching_time_sync_button_configuration: SensorConfiguration):
+        self._time_sync_button_configuration = matching_time_sync_button_configuration
+        if(self._mczDateTimeEntity is not None):
+            self._mczDateTimeEntity.set_date_time_configuration(matching_time_sync_button_configuration)
+      
+
+    async def async_press(self) -> None:
+        """Button pressed action execute."""
+        if(self._time_sync_button_configuration is not None and self._mczDateTimeEntity is not None):
+            system_date_time = dt_util.utcnow()
+            if(system_date_time is not None):
+                await self._mczDateTimeEntity.async_set_value(system_date_time)
+                await self.coordinator.update_data_after_set()
+
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/maestro_mcz/climate.py
+++ b/custom_components/maestro_mcz/climate.py
@@ -51,7 +51,7 @@ class MczClimateEntity(CoordinatorEntity, ClimateEntity):
     _thermostat_configuration: SensorConfiguration | None = None
 
     
-    def __init__(self, coordinator:MczCoordinator, supported_power_sensor: models.PowerSettingMczConfigItem, matching_power_configuration: SensorConfiguration):
+    def __init__(self, coordinator:MczCoordinator, supported_power_sensor: models.PowerSettingMczConfigItem, matching_power_configuration: SensorConfiguration) -> None:
         super().__init__(coordinator)
         self.coordinator:MczCoordinator = coordinator
 

--- a/custom_components/maestro_mcz/fan.py
+++ b/custom_components/maestro_mcz/fan.py
@@ -52,7 +52,7 @@ class MczFanEntity(CoordinatorEntity, FanEntity):
     _fan_configuration: SensorConfigurationMultipleModes | None = None
     _current_fan_configuration: SensorConfiguration | None = None
 
-    def __init__(self, coordinator, supported_fan: models.FanMczConfigItem, matching_fan_configuration: SensorConfigurationMultipleModes):
+    def __init__(self, coordinator, supported_fan: models.FanMczConfigItem, matching_fan_configuration: SensorConfigurationMultipleModes) -> None:
         super().__init__(coordinator)
         self.coordinator:MczCoordinator = coordinator
         self._attr_name = supported_fan.user_friendly_name

--- a/custom_components/maestro_mcz/models.py
+++ b/custom_components/maestro_mcz/models.py
@@ -196,6 +196,29 @@ class DateTimeMczConfigItem(MczConfigItem):
         self.enabled_by_default = enabled_by_default
 
 @dataclass
+class TimeSyncButtonMczConfigItem(DateTimeMczConfigItem):
+    def __init__(self, user_friendly_name:str, sensor_get_name:str, sensor_set_name:str,
+                sensor_get_name_weekday:str, sensor_set_name_weekday:str, 
+                sensor_get_name_year:str, sensor_set_name_year:str,
+                sensor_get_name_month:str, sensor_set_name_month:str,
+                sensor_get_name_day:str, sensor_set_name_day:str,
+                sensor_get_name_hour:str, sensor_set_name_hour:str,
+                sensor_get_name_minute:str, sensor_set_name_minute:str,
+                sensor_get_name_second:str, sensor_set_name_second:str,
+                sensor_get_name_am_pm:str, sensor_set_name_am_pm:str,
+                sensor_set_config_name:str, icon:str, category: EntityCategory | None, enabled_by_default: bool):
+        super().__init__(user_friendly_name, sensor_get_name, sensor_set_name,
+                sensor_get_name_weekday, sensor_set_name_weekday, 
+                sensor_get_name_year, sensor_set_name_year,
+                sensor_get_name_month, sensor_set_name_month,
+                sensor_get_name_day, sensor_set_name_day,
+                sensor_get_name_hour, sensor_set_name_hour,
+                sensor_get_name_minute, sensor_set_name_minute,
+                sensor_get_name_second, sensor_set_name_second,
+                sensor_get_name_am_pm, sensor_set_name_am_pm,
+                sensor_set_config_name, icon, category, enabled_by_default)
+
+@dataclass
 class PotMczConfigItem(SelectMczConfigItem):
 
     def __init__(self, user_friendly_name:str, sensor_get_name:str, sensor_set_name:str, sensor_set_config_name:str, enabled_by_default: bool):
@@ -327,6 +350,31 @@ supported_date_times = [
 supported_buttons = [
     ButtonMczConfigItem("Alarm Reset","com_reset_allarm","Reset Allarme","mdi:auto-fix", EntityCategory.DIAGNOSTIC, True),
     ButtonMczConfigItem("Alarm Reset","m1_com_reset_allarm","Reset Allarme","mdi:auto-fix", EntityCategory.DIAGNOSTIC, True), #for first generation M1+
+]
+
+supported_time_sync_buttons = [
+    TimeSyncButtonMczConfigItem("Set System Date & Time",
+                                "giorno", "giorno",
+                                "giorno_sett", "giorno_sett",
+                                "anno", "anno",
+                                "mese", "mese",
+                                "giorno", "giorno",
+                                "ore", "ore",
+                                "minuti", "minuti",
+                                "secondi", "secondi",
+                                "am_pm","am_pm",
+                                "Orodatario", "mdi:calendar-clock", EntityCategory.CONFIG, True),
+    TimeSyncButtonMczConfigItem("Set System Date & Time",
+                                "giorno", "m1_giorno",
+                                None, None,
+                                "anno", "m1_anno",
+                                "mese", "m1_mese",
+                                "giorno", "m1_giorno",
+                                "ore", "m1_ore",
+                                "minuti", "m1_minuti",
+                                None, None,
+                                None, None,
+                                "Orodatario", "mdi:calendar-clock", EntityCategory.CONFIG, True),  #for first generation M1+  
 ]
 
 supported_binary_sensors = [

--- a/custom_components/maestro_mcz/number.py
+++ b/custom_components/maestro_mcz/number.py
@@ -39,7 +39,7 @@ class MczNumberEntity(CoordinatorEntity, NumberEntity):
     # 
     _number_configuration: SensorConfiguration | None = None
 
-    def __init__(self, coordinator, supported_number:models.NumberMczConfigItem, matching_number_configuration: SensorConfiguration):
+    def __init__(self, coordinator, supported_number:models.NumberMczConfigItem, matching_number_configuration: SensorConfiguration)-> None:
         super().__init__(coordinator)
         self.coordinator:MczCoordinator = coordinator
         self._attr_name = supported_number.user_friendly_name

--- a/custom_components/maestro_mcz/select.py
+++ b/custom_components/maestro_mcz/select.py
@@ -42,7 +42,7 @@ class MczSelectEntity(CoordinatorEntity, SelectEntity):
      # 
     _selector_configuration: SensorConfiguration | None = None
 
-    def __init__(self, coordinator, supported_selector:models.SelectMczConfigItem, matching_selector_configuration: SensorConfiguration):
+    def __init__(self, coordinator, supported_selector:models.SelectMczConfigItem, matching_selector_configuration: SensorConfiguration) -> None:
         super().__init__(coordinator)
         self.coordinator:MczCoordinator = coordinator
         self._attr_name = supported_selector.user_friendly_name

--- a/custom_components/maestro_mcz/sensor.py
+++ b/custom_components/maestro_mcz/sensor.py
@@ -30,7 +30,7 @@ class MczSensorEntity(CoordinatorEntity, SensorEntity):
     _attr_has_entity_name = True
     _attr_native_value = None
 
-    def __init__(self, coordinator, supported_sensor:models.SensorMczConfigItem):
+    def __init__(self, coordinator, supported_sensor:models.SensorMczConfigItem) -> None:
         super().__init__(coordinator)
         self.coordinator:MczCoordinator = coordinator
         self._attr_name = supported_sensor.user_friendly_name


### PR DESCRIPTION
We've added the ability to set the Date & Time of your Home Assistant System on your stove with:

- Single button press
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/3ec77b85-e9ce-4e6d-91c8-22bab3ef04b7)
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/4918a4be-f078-4d6b-9496-2201f2d1d7d4)

- An action into a Automation
![image](https://github.com/Robbe-B/maestro_mcz/assets/103053873/110eb037-0b26-43d7-8167-57c7497feac3)

