### PR TITLE
Fix exceptions while trying to setup datetime entity

### DIFF
--- a/custom_components/maestro_mcz/datetime.py
+++ b/custom_components/maestro_mcz/datetime.py
@@ -237,22 +237,28 @@ class MczDateTimeEntity(CoordinatorEntity, DateTimeEntity):
             self._attr_weekday = None
 
         if(year is not None and 
+           year != 0 and
            month is not None and
+           month != 0 and
            day is not None and
+           day != 0 and
            hour is not None and
            minute is not None): 
             if(second is None):
                 second = 0
-                
-            self._attr_native_value = datetime(
-                year=year,
-                month=month,
-                day=day,
-                hour=hour,
-                minute=minute,
-                second=second,
-                tzinfo=dt_util.DEFAULT_TIME_ZONE,
-            )        
+
+            try:   
+                self._attr_native_value = datetime(
+                    year=year,
+                    month=month,
+                    day=day,
+                    hour=hour,
+                    minute=minute,
+                    second=second,
+                    tzinfo=dt_util.DEFAULT_TIME_ZONE
+                )
+            except:
+                self._attr_native_value = None                
         else:     
             self._attr_native_value = None
             


### PR DESCRIPTION
Fix exceptions while trying to setup datetime entity when stove is unplugged.