### PR TITLE
Fix duplicate entities when the stove is disconnected.

### DIFF
--- a/custom_components/maestro_mcz/__init__.py
+++ b/custom_components/maestro_mcz/__init__.py
@@ -55,7 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         stove:MaestroStove = stove
         coordinator = MczCoordinator(hass, stove, pollling_interval)
         await coordinator.async_config_entry_first_refresh()
-        if(coordinator.maestroapi.UniqueCode): #avoid adding a disconnected stove without serial number
+        if(coordinator.maestroapi.UniqueCode): #avoid adding a stove without serial number as this is the unique identifier in HA
             stoveList.append(coordinator)
 
     hass.data[DOMAIN][entry.entry_id] = stoveList

--- a/custom_components/maestro_mcz/binary_sensor.py
+++ b/custom_components/maestro_mcz/binary_sensor.py
@@ -36,7 +36,7 @@ class MczBinarySensorEntity(CoordinatorEntity, BinarySensorEntity):
         self.coordinator:MczCoordinator = coordinator
         self._attr_name = supported_binary_sensor.user_friendly_name
         self._attr_device_class = supported_binary_sensor.device_class
-        self._attr_unique_id = f"{self.coordinator._maestroapi.Status.sm_sn}-{supported_binary_sensor.sensor_get_name}"
+        self._attr_unique_id = f"{self.coordinator.maestroapi.UniqueCode}-{supported_binary_sensor.sensor_get_name}"
         self._attr_icon = supported_binary_sensor.icon
         self._prop = supported_binary_sensor.sensor_get_name
         self._enabled_default = supported_binary_sensor.enabled_by_default

--- a/custom_components/maestro_mcz/button.py
+++ b/custom_components/maestro_mcz/button.py
@@ -50,7 +50,7 @@ class MczButtonEntity(CoordinatorEntity, ButtonEntity):
         super().__init__(coordinator)
         self.coordinator:MczCoordinator = coordinator
         self._attr_name = supported_button.user_friendly_name
-        self._attr_unique_id = f"{self.coordinator._maestroapi.Status.sm_sn}-{supported_button.sensor_set_name}"
+        self._attr_unique_id = f"{self.coordinator.maestroapi.UniqueCode}-{supported_button.sensor_set_name}"
         self._attr_icon = supported_button.icon
         self._prop = supported_button.sensor_set_name
         self._enabled_default = supported_button.enabled_by_default
@@ -111,7 +111,7 @@ class MczTimeSyncButtonEntity(CoordinatorEntity, ButtonEntity):
         self._mczDateTimeEntity = MczDateTimeEntity(coordinator, supported_time_sync_button, matching_time_sync_button_configuration)
 
         self._attr_name = supported_time_sync_button.user_friendly_name
-        self._attr_unique_id = f"{self.coordinator._maestroapi.Status.sm_sn}-{supported_time_sync_button.sensor_set_name}"
+        self._attr_unique_id = f"{self.coordinator.maestroapi.UniqueCode}-{supported_time_sync_button.sensor_set_name}"
         self._attr_icon = supported_time_sync_button.icon
         self._prop = supported_time_sync_button.sensor_set_name
         self._enabled_default = supported_time_sync_button.enabled_by_default

--- a/custom_components/maestro_mcz/climate.py
+++ b/custom_components/maestro_mcz/climate.py
@@ -57,7 +57,7 @@ class MczClimateEntity(CoordinatorEntity, ClimateEntity):
 
         #general 
         self._attr_name = None
-        self._attr_unique_id = f"{self.coordinator._maestroapi.Status.sm_sn}"
+        self._attr_unique_id = f"{self.coordinator.maestroapi.UniqueCode}"
         self._attr_icon = "mdi:stove"
 
         #set power on/off config

--- a/custom_components/maestro_mcz/datetime.py
+++ b/custom_components/maestro_mcz/datetime.py
@@ -56,7 +56,7 @@ class MczDateTimeEntity(CoordinatorEntity, DateTimeEntity):
         super().__init__(coordinator)
         self.coordinator:MczCoordinator = coordinator
         self._attr_name = supported_date_time.user_friendly_name
-        self._attr_unique_id = f"{self.coordinator._maestroapi.Status.sm_sn}-{supported_date_time.sensor_set_name}"
+        self._attr_unique_id = f"{self.coordinator.maestroapi.UniqueCode}-{supported_date_time.sensor_set_name}"
         self._attr_icon = supported_date_time.icon
         self._prop = supported_date_time.sensor_set_name
         self._enabled_default = supported_date_time.enabled_by_default

--- a/custom_components/maestro_mcz/fan.py
+++ b/custom_components/maestro_mcz/fan.py
@@ -56,7 +56,7 @@ class MczFanEntity(CoordinatorEntity, FanEntity):
         super().__init__(coordinator)
         self.coordinator:MczCoordinator = coordinator
         self._attr_name = supported_fan.user_friendly_name
-        self._attr_unique_id = f"{self.coordinator._maestroapi.Status.sm_sn}-{supported_fan.sensor_get_name}"
+        self._attr_unique_id = f"{self.coordinator.maestroapi.UniqueCode}-{supported_fan.sensor_get_name}"
         self._attr_icon = supported_fan.icon
         self._prop = supported_fan.sensor_get_name
         self._enabled_default = supported_fan.enabled_by_default

--- a/custom_components/maestro_mcz/number.py
+++ b/custom_components/maestro_mcz/number.py
@@ -45,7 +45,7 @@ class MczNumberEntity(CoordinatorEntity, NumberEntity):
         self._attr_name = supported_number.user_friendly_name
         self._attr_native_unit_of_measurement = supported_number.unit
         self._attr_device_class = supported_number.device_class
-        self._attr_unique_id = f"{self.coordinator._maestroapi.Status.sm_sn}-{supported_number.sensor_get_name}"
+        self._attr_unique_id = f"{self.coordinator.maestroapi.UniqueCode}-{supported_number.sensor_get_name}"
         self._attr_icon = supported_number.icon
         self._attr_mode = supported_number.mode
         self._prop = supported_number.sensor_get_name

--- a/custom_components/maestro_mcz/select.py
+++ b/custom_components/maestro_mcz/select.py
@@ -46,7 +46,7 @@ class MczSelectEntity(CoordinatorEntity, SelectEntity):
         super().__init__(coordinator)
         self.coordinator:MczCoordinator = coordinator
         self._attr_name = supported_selector.user_friendly_name
-        self._attr_unique_id = f"{self.coordinator._maestroapi.Status.sm_sn}-{supported_selector.sensor_get_name}"
+        self._attr_unique_id = f"{self.coordinator.maestroapi.UniqueCode}-{supported_selector.sensor_get_name}"
         self._attr_icon = supported_selector.icon
         self._prop = supported_selector.sensor_get_name
         self._enabled_default = supported_selector.enabled_by_default

--- a/custom_components/maestro_mcz/sensor.py
+++ b/custom_components/maestro_mcz/sensor.py
@@ -38,7 +38,7 @@ class MczSensorEntity(CoordinatorEntity, SensorEntity):
         self._attr_suggested_display_precision = supported_sensor.display_precision
         self._attr_device_class = supported_sensor.device_class
         self._attr_state_class = supported_sensor.state_class
-        self._attr_unique_id = f"{self.coordinator._maestroapi.Status.sm_sn}-{supported_sensor.sensor_get_name}"
+        self._attr_unique_id = f"{self.coordinator.maestroapi.UniqueCode}-{supported_sensor.sensor_get_name}"
         self._attr_icon = supported_sensor.icon
         self._prop = supported_sensor.sensor_get_name
         self._enabled_default = supported_sensor.enabled_by_default

--- a/custom_components/maestro_mcz/switch.py
+++ b/custom_components/maestro_mcz/switch.py
@@ -39,7 +39,7 @@ class MczSwitchEntity(CoordinatorEntity, SwitchEntity):
         super().__init__(coordinator)
         self.coordinator:MczCoordinator = coordinator
         self._attr_name = supported_switch.user_friendly_name
-        self._attr_unique_id = f"{self.coordinator._maestroapi.Status.sm_sn}-{supported_switch.sensor_get_name}"
+        self._attr_unique_id = f"{self.coordinator.maestroapi.UniqueCode}-{supported_switch.sensor_get_name}"
         self._attr_icon = supported_switch.icon
         self._prop = supported_switch.sensor_get_name
         self._enabled_default = supported_switch.enabled_by_default


### PR DESCRIPTION
When a stove is disconnected, the serial number becomes empty.
Therefore HA is creating duplicate entities since this information was used to create the unique identifier for the entities.
This has now been addressed.

NOTE: For some stove models this might create a duplicate stove device entity inside the integration after upgrading to this version.
In that case just re-adding the integration from scratch should solve your problem