### PR TITLE
M1 models => Avoid reporting "heat" on alarm

### DIFF
--- a/custom_components/maestro_mcz/climate.py
+++ b/custom_components/maestro_mcz/climate.py
@@ -321,6 +321,9 @@ class MczClimateEntity(CoordinatorEntity, ClimateEntity):
                             case 46:  # standby
                                 self._attr_hvac_action = HVACAction.IDLE
                                 self._attr_hvac_mode = HVACMode.HEAT
+                            case 51: #alarm
+                                self._attr_hvac_action = HVACAction.OFF
+                                self._attr_hvac_mode = HVACMode.OFF
                             case _:  # default (on)
                                 self._attr_hvac_action = HVACAction.HEATING
                                 self._attr_hvac_mode = HVACMode.HEAT


### PR DESCRIPTION
For M1 models only

We now avoid showing the stove in the "heat" state when an alarm is present.